### PR TITLE
Dataset Switch, Env reconfigure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ chuvak*
 logs
 .idea
 data/bert/
+data/finished_files/
+.DS_Store
 .vscode/
 __pycache__
 gym_summarizer.egg-info


### PR DESCRIPTION
- Added CNNDMLoader
- Added code to precompute embeddings and load if available

todo:
- Integrate validation and testing in env
- Missing docstrings
- Add env option that doesn't flatten article